### PR TITLE
macOS: fix build tag

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ github.event.pull_request.head.sha }} # to match buildomat behavior
+          fetch-depth: 0 # to fetch tags
       - name: Toolchain setup
         run: |
           set -o xtrace


### PR DESCRIPTION
`actions/checkout` defaults to using `--depth 1`, which prevents fetching tags and understanding the history between the most recent Git tag and the current commit. This prevents `git describe` and thus `cockroach version` from usefully outputting something like `v22.1.22-25-g24e7b94071`.