### PR TITLE
fix #3: get GEOS building on modern compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -558,7 +558,7 @@ $(GEOS_DIR)/Makefile: $(C_DEPS_DIR)/geos-rebuild | bin/.submodules-initialized
 	@# NOTE: If you change the CMake flags below, bump the version in
 	@# $(C_DEPS_DIR)/geos-rebuild. See above for rationale.
 	cd $(GEOS_DIR) && \
-	  cmake $(xcmake-flags) $(GEOS_SRC_DIR) -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS=-fPIC
+	  cmake $(xcmake-flags) $(GEOS_SRC_DIR) -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS="-fPIC -include cstdint"
 	@# Copy geos/export.h to the capi include directory to avoid needing multiple include
 	@# directories.
 	mkdir $(GEOS_DIR)/capi/geos

--- a/Makefile
+++ b/Makefile
@@ -558,7 +558,7 @@ $(GEOS_DIR)/Makefile: $(C_DEPS_DIR)/geos-rebuild | bin/.submodules-initialized
 	@# NOTE: If you change the CMake flags below, bump the version in
 	@# $(C_DEPS_DIR)/geos-rebuild. See above for rationale.
 	cd $(GEOS_DIR) && \
-	  cmake $(xcmake-flags) $(GEOS_SRC_DIR) -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS="-fPIC -include cstdint"
+	  cmake $(xcmake-flags) $(GEOS_SRC_DIR) -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS="-fPIC -include cstddef -include cstdint"
 	@# Copy geos/export.h to the capi include directory to avoid needing multiple include
 	@# directories.
 	mkdir $(GEOS_DIR)/capi/geos

--- a/c-deps/geos-rebuild
+++ b/c-deps/geos-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing geos configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-8
+9


### PR DESCRIPTION
This is an absolutely terrible hack but it sure beats spending time figuring out how to patch the submodule or fix all the tests for a later GEOS.