### PR TITLE
add LDFLAGS: -ltinfo to go-libedit

### DIFF
--- a/patches/go-libedit.patch
+++ b/patches/go-libedit.patch
@@ -1,0 +1,11 @@
+--- a/vendor/github.com/knz/go-libedit/unix/editline_unix.go
++++ b/vendor/github.com/knz/go-libedit/unix/editline_unix.go
+@@ -27,7 +27,7 @@ import (
+ 
+ // #cgo openbsd netbsd illumos freebsd dragonfly darwin LDFLAGS: -ledit
+ // #cgo openbsd netbsd illumos freebsd dragonfly darwin CPPFLAGS: -Ishim
+-// #cgo linux LDFLAGS: -lncurses
++// #cgo linux LDFLAGS: -lncurses -ltinfo
+ // #cgo linux CFLAGS: -Wno-unused-result -Wno-pointer-sign
+ // #cgo linux CPPFLAGS: -Isrc -Isrc/c-libedit -Isrc/c-libedit/editline -Isrc/c-libedit/linux-build -D_GNU_SOURCE
+ //


### PR DESCRIPTION
Necessary for building on Gentoo for whatever reason; otherwise:

```
# github.com/cockroachdb/cockroach/pkg/cmd/cockroach-oss
/home/iliana/sdk/go1.22.11/pkg/tool/linux_amd64/link: running g++ failed: exit status 1
/usr/lib/gcc/x86_64-pc-linux-gnu/15/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/go-link-2930997610/000077.o: undefined reference to symbol 'tgetstr'
/usr/lib/gcc/x86_64-pc-linux-gnu/15/../../../../x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libtinfo.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```