### PR TITLE
Revert "work around illumos#16834 in test suite"

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -270,15 +270,12 @@ true
 subtest regression_django-cockroachdb_120
 
 statement ok
-SET TIME ZONE 'America/Halifax'
+SET TIME ZONE 'America/Chicago'
 
 query T
-SELECT '1882-05-23T00:00:00-04:15'::timestamptz::text
+SELECT '1882-05-23T00:00:00-05:51'::timestamptz::text
 ----
-1882-05-23 00:00:36-04:14:24
-
-statement ok
-SET TIME ZONE 'America/Chicago'
+1882-05-23 00:00:24-05:50:36
 
 query B
 SELECT '2011-03-13'::date = '2011-03-13'::timestamp

--- a/pkg/sql/pgwire/testdata/pgtest/timezone
+++ b/pkg/sql/pgwire/testdata/pgtest/timezone
@@ -46,24 +46,24 @@ ReadyForQuery
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 send
-Query {"String": "SET TIME ZONE \"America/Halifax\""}
+Query {"String": "SET TIME ZONE \"America/Chicago\""}
 ----
 
 until
 ReadyForQuery
 ----
-{"Type":"ParameterStatus","Name":"TimeZone","Value":"America/Halifax"}
+{"Type":"ParameterStatus","Name":"TimeZone","Value":"America/Chicago"}
 {"Type":"CommandComplete","CommandTag":"SET"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 send
-Query {"String": "SELECT '1882-05-23T00:00:00-04:15'::\"timestamptz\""}
+Query {"String": "SELECT '1882-05-23T00:00:00-05:51'::\"timestamptz\""}
 ----
 
 until ignore_data_type_sizes
 ReadyForQuery
 ----
 {"Type":"RowDescription","Fields":[{"Name":"timestamptz","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":1184,"DataTypeSize":0,"TypeModifier":-1,"Format":0}]}
-{"Type":"DataRow","Values":[{"text":"1882-05-23 00:00:36-04:14:24"}]}
+{"Type":"DataRow","Values":[{"text":"1882-05-23 00:00:24-05:50:36"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
The fix for illumos#16834 has landed, so let's put the original test data back.

This reverts commit 9695d99e09959b277baefcaaa11bd703134f1ae3.