### PR TITLE
fix printf-related go vet violations

### DIFF
--- a/pkg/cmd/release/sender_test.go
+++ b/pkg/cmd/release/sender_test.go
@@ -137,7 +137,7 @@ func TestPostBlockers(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(fmt.Sprintf(test.testCase), func(t *testing.T) {
+		t.Run(test.testCase, func(t *testing.T) {
 			var expectedMessage *message
 			defer hookGlobal(
 				&sendmail,

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -551,6 +551,6 @@ func shout(
 		format += "\n"
 	}
 	msg := fmt.Sprintf(format, args...)
-	l.PrintfCtxDepth(ctx, 2 /* depth */, msg)
+	l.PrintfCtxDepth(ctx, 2 /* depth */, "%s", msg)
 	fmt.Fprint(stdout, msg)
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -643,7 +643,7 @@ func (r *testRunner) runWorker(
 				msg = "test failed: %s (run %d)"
 			}
 			msg = fmt.Sprintf(msg, t.Name(), testToRun.runNum)
-			l.PrintfCtx(ctx, msg)
+			l.PrintfCtx(ctx, "%s", msg)
 		}
 		testL.Close()
 		if err != nil || t.Failed() {

--- a/pkg/cmd/roachtest/tests/drain.go
+++ b/pkg/cmd/roachtest/tests/drain.go
@@ -204,7 +204,7 @@ func runEarlyExitInConnectionWait(ctx context.Context, t test.Test, c cluster.Cl
 	drainEndTimestamp := timeutil.Now()
 	actualDrainDuration := drainEndTimestamp.Sub(drainStartTimestamp)
 
-	t.L().Printf("the draining lasted %f seconds", actualDrainDuration)
+	t.L().Printf("the draining lasted %f seconds", actualDrainDuration.Seconds())
 
 	totalWaitDuration := drainWaitDuration + connectionWaitDuration + queryWaitDuration
 	if actualDrainDuration >= totalWaitDuration-10*time.Second {

--- a/pkg/cmd/roachtest/tests/drop.go
+++ b/pkg/cmd/roachtest/tests/drop.go
@@ -131,7 +131,7 @@ func registerDrop(r registry.Registry) {
 					}
 
 					nodeSpaceUsed := fmt.Sprintf("Node %d space after deletion used: %s\n", j, humanizeutil.IBytes(int64(size)))
-					t.L().Printf(nodeSpaceUsed)
+					t.L().Printf("%s", nodeSpaceUsed)
 
 					// Return if the size of the directory is less than 100mb
 					if size > maxSizeBytes {
@@ -149,7 +149,7 @@ func registerDrop(r registry.Registry) {
 			if !allNodesSpaceCleared {
 				sizeReport += fmt.Sprintf("disk space usage has not dropped below %s on all nodes.",
 					humanizeutil.IBytes(int64(maxSizeBytes)))
-				t.Fatalf(sizeReport)
+				t.Fatalf("%s", sizeReport)
 			}
 
 			return nil

--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -125,9 +125,9 @@ SELECT string_agg(source_id::TEXT || ':' || target_id::TEXT, ',')
 					return false
 				}
 
-				for i := range liveNodes {
-					if liveNodes[i] != expLiveNodes[i] {
-						t.L().Printf("%d: gossip not ok (mismatched view of live nodes); expected %s, got %s (%.0fs)\n",
+				for j := range liveNodes {
+					if liveNodes[j] != expLiveNodes[j] {
+						t.L().Printf("%d: gossip not ok (mismatched view of live nodes: %s); expected %v, got %v (%.0fs)\n",
 							i, gossipNetwork, expLiveNodes, liveNodes, timeutil.Since(start).Seconds())
 						return false
 					}

--- a/pkg/cmd/roachtest/tests/kvbench.go
+++ b/pkg/cmd/roachtest/tests/kvbench.go
@@ -263,7 +263,7 @@ func runKVBench(ctx context.Context, t test.Test, c cluster.Cluster, b kvBenchSp
 				splitCmd.WriteString(`;`)
 			}
 			if _, err := db.Exec(splitCmd.String()); err != nil {
-				t.L().Printf(splitCmd.String())
+				t.L().Printf("%s", splitCmd.String())
 				return err
 			}
 

--- a/pkg/cmd/roachtest/tests/network.go
+++ b/pkg/cmd/roachtest/tests/network.go
@@ -280,7 +280,7 @@ SELECT $1::INT = ALL (
 					"--url", url, "--certs-dir", certsDir, "-e", "'SELECT 1'")
 
 				// Report the results of execution.
-				t.L().Printf("server %d, attempt %d, result:\n%s\n", server, attempt, b)
+				t.L().Printf("server %d, attempt %d, result:\n%+v\n", server, attempt, b)
 				// Indicate, to the main goroutine, that we have at least one connection
 				// attempt completed.
 				atomic.AddUint32(&numConns, 1)

--- a/pkg/cmd/roachtest/tests/replicagc.go
+++ b/pkg/cmd/roachtest/tests/replicagc.go
@@ -252,7 +252,7 @@ func (h *replicagcTestHelper) isolateDeadNodes(ctx context.Context, runNode int)
 		"RANGE default", "RANGE meta", "RANGE system", "RANGE liveness", "DATABASE system", "TABLE system.jobs",
 	} {
 		stmt := `ALTER ` + change + ` CONFIGURE ZONE = 'constraints: {"-` + deadNodeAttr + `"}'`
-		h.t.L().Printf(stmt + "\n")
+		h.t.L().Printf("%s\n", stmt)
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			h.t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/reset_quorum.go
+++ b/pkg/cmd/roachtest/tests/reset_quorum.go
@@ -95,7 +95,7 @@ OR
 		if buf.Len() == 0 {
 			break
 		}
-		t.L().Printf("still waiting:\n" + buf.String())
+		t.L().Printf("still waiting:\n%s", buf.String())
 		time.Sleep(5 * time.Second)
 	}
 

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -144,7 +144,7 @@ func (hc *HealthChecker) Runner(ctx context.Context) (err error) {
 			rr = append(rr, a)
 		}
 		if len(rr) > 0 {
-			logger.Printf(rr.String() + "\n")
+			logger.Printf("%s\n", rr.String())
 			// TODO(tschottdorf): see method comment.
 			// return errors.New(rr.String())
 		}

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -300,7 +300,7 @@ INSERT INTO seed_mr_table DEFAULT VALUES;`, regionList[0]),
 					sb.WriteString(errStr)
 					sb.WriteString(hintStr)
 
-					t.Fatalf(sb.String())
+					t.Fatalf("%s", sb.String())
 				}
 			}
 		}

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -233,18 +233,18 @@ func (p *tpchVecPerfTest) postTestRunHook(
 		vecOffTime := findMedian(vecOffTimes)
 		if vecOffTime < vecOnTime {
 			t.L().Printf(
-				fmt.Sprintf("[q%d] vec OFF was faster by %.2f%%: "+
+				"[q%d] vec OFF was faster by %.2f%%: "+
 					"%.2fs ON vs %.2fs OFF --- WARNING\n"+
 					"vec ON times: %v\t vec OFF times: %v",
-					queryNum, 100*(vecOnTime-vecOffTime)/vecOffTime,
-					vecOnTime, vecOffTime, vecOnTimes, vecOffTimes))
+				queryNum, 100*(vecOnTime-vecOffTime)/vecOffTime,
+				vecOnTime, vecOffTime, vecOnTimes, vecOffTimes)
 		} else {
 			t.L().Printf(
-				fmt.Sprintf("[q%d] vec ON was faster by %.2f%%: "+
+				"[q%d] vec ON was faster by %.2f%%: "+
 					"%.2fs ON vs %.2fs OFF\n"+
 					"vec ON times: %v\t vec OFF times: %v",
-					queryNum, 100*(vecOffTime-vecOnTime)/vecOnTime,
-					vecOnTime, vecOffTime, vecOnTimes, vecOffTimes))
+				queryNum, 100*(vecOffTime-vecOnTime)/vecOnTime,
+				vecOnTime, vecOffTime, vecOnTimes, vecOffTimes)
 		}
 		if vecOnTime >= tpchVecPerfSlownessThreshold*vecOffTime {
 			// For some reason, the vectorized engine executed the query a lot
@@ -407,11 +407,11 @@ func (b *tpchVecBenchTest) postTestRunHook(
 				bestSetupIdx = setupIdx
 			}
 		}
-		t.L().Printf(fmt.Sprintf("[q%d] best setup is %s", queryNum, runConfig.setupNames[bestSetupIdx]))
+		t.L().Printf("[q%d] best setup is %s", queryNum, runConfig.setupNames[bestSetupIdx])
 		for setupIdx, setupName := range runConfig.setupNames {
 			setupTime := findAvgTime(b.timeByQueryNum[setupIdx][queryNum])
 			scores[setupIdx] += setupTime / bestTime
-			t.L().Printf(fmt.Sprintf("[q%d] setup %s took %.2fs", queryNum, setupName, setupTime))
+			t.L().Printf("[q%d] setup %s took %.2fs", queryNum, setupName, setupTime)
 		}
 	}
 	t.Status("----- scores of the setups -----")
@@ -419,7 +419,7 @@ func (b *tpchVecBenchTest) postTestRunHook(
 	var bestSetupIdx int
 	for setupIdx, setupName := range runConfig.setupNames {
 		score := scores[setupIdx]
-		t.L().Printf(fmt.Sprintf("score of %s is %.2f", setupName, score))
+		t.L().Printf("score of %s is %.2f", setupName, score)
 		if bestScore > score {
 			bestScore = score
 			bestSetupIdx = setupIdx
@@ -474,7 +474,7 @@ func baseTestRun(
 				runConfig.numRunsPerQuery, queryNum)
 			result, err := c.RunWithDetailsSingleNode(ctx, t.L(), firstNode, cmd)
 			workloadOutput := result.Stdout + result.Stderr
-			t.L().Printf(workloadOutput)
+			t.L().Printf("%s", workloadOutput)
 			if err != nil {
 				// Note: if you see an error like "exit status 1", it is likely caused
 				// by the erroneous output of the query.

--- a/pkg/geo/geomfn/make_geometry_test.go
+++ b/pkg/geo/geomfn/make_geometry_test.go
@@ -251,7 +251,7 @@ func TestMakePolygon(t *testing.T) {
 			}
 			polygon, err := MakePolygon(outer, interior...)
 			if tc.err != nil {
-				require.Errorf(t, err, tc.err.Error())
+				require.Errorf(t, err, "%s", tc.err.Error())
 				require.EqualError(t, err, tc.err.Error())
 			} else {
 				require.NoError(t, err)

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -467,7 +467,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				mon.runSync("update txn", func(ctx context.Context) {
 					log.Eventf(ctx, "%s %s", verb, txnName)
 					if err := c.updateTxnRecord(txn.ID, status, ts); err != nil {
-						d.Fatalf(t, err.Error())
+						d.Fatalf(t, "%s", err.Error())
 					}
 				})
 				return c.waitAndCollect(t, mon)

--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -59,7 +59,7 @@ type raftLogger struct {
 
 func (r *raftLogger) Debug(v ...interface{}) {
 	if log.V(3) {
-		log.InfofDepth(r.ctx, 1, "", v...)
+		log.InfofDepth(r.ctx, 1, "%s", fmt.Sprint(v...))
 	}
 }
 
@@ -71,7 +71,7 @@ func (r *raftLogger) Debugf(format string, v ...interface{}) {
 
 func (r *raftLogger) Info(v ...interface{}) {
 	if log.V(2) {
-		log.InfofDepth(r.ctx, 1, "", v...)
+		log.InfofDepth(r.ctx, 1, "%s", fmt.Sprint(v...))
 	}
 }
 
@@ -82,7 +82,7 @@ func (r *raftLogger) Infof(format string, v ...interface{}) {
 }
 
 func (r *raftLogger) Warning(v ...interface{}) {
-	log.WarningfDepth(r.ctx, 1, "", v...)
+	log.WarningfDepth(r.ctx, 1, "%s", fmt.Sprint(v...))
 }
 
 func (r *raftLogger) Warningf(format string, v ...interface{}) {
@@ -90,7 +90,7 @@ func (r *raftLogger) Warningf(format string, v ...interface{}) {
 }
 
 func (r *raftLogger) Error(v ...interface{}) {
-	log.ErrorfDepth(r.ctx, 1, "", v...)
+	log.ErrorfDepth(r.ctx, 1, "%s", fmt.Sprint(v...))
 }
 
 func (r *raftLogger) Errorf(format string, v ...interface{}) {
@@ -99,7 +99,7 @@ func (r *raftLogger) Errorf(format string, v ...interface{}) {
 
 func (r *raftLogger) Fatal(v ...interface{}) {
 	wrapNumbersAsSafe(v)
-	log.FatalfDepth(r.ctx, 1, "", v...)
+	log.FatalfDepth(r.ctx, 1, "%s", fmt.Sprint(v...))
 }
 
 func (r *raftLogger) Fatalf(format string, v ...interface{}) {
@@ -109,7 +109,7 @@ func (r *raftLogger) Fatalf(format string, v ...interface{}) {
 
 func (r *raftLogger) Panic(v ...interface{}) {
 	wrapNumbersAsSafe(v)
-	log.FatalfDepth(r.ctx, 1, "", v...)
+	log.FatalfDepth(r.ctx, 1, "%s", fmt.Sprint(v...))
 }
 
 func (r *raftLogger) Panicf(format string, v ...interface{}) {

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1473,8 +1473,8 @@ func (c *SyncedCluster) Put(ctx context.Context, l *logger.Logger, src, dest str
 			return err
 		}
 		redColor, resetColor := "\033[31m", "\033[0m"
-		l.Printf(redColor + "WARNING: Source file is a symlink." + resetColor)
-		l.Printf(redColor+"WARNING: Remote file will inherit the target permissions '%v'."+resetColor, symlinkTargetInfo.Mode())
+		l.Printf("%sWARNING: Source file is a symlink.%s", redColor, resetColor)
+		l.Printf("%sWARNING: Remote file will inherit the target permissions '%v'.%s", redColor, symlinkTargetInfo.Mode(), resetColor)
 	}
 
 	// NB: This value was determined with a few experiments. Higher values were

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -650,7 +650,7 @@ func (c *SyncedCluster) initializeCluster(ctx context.Context, l *logger.Logger,
 	}
 
 	if out := strings.TrimSpace(string(out)); out != "" {
-		l.Printf(out)
+		l.Printf("%s", out)
 	}
 	return nil
 }
@@ -667,7 +667,7 @@ func (c *SyncedCluster) setClusterSettings(ctx context.Context, l *logger.Logger
 		return errors.Wrapf(err, "~ %s\n%s", cmd, out)
 	}
 	if out := strings.TrimSpace(string(out)); out != "" {
-		l.Printf(out)
+		l.Printf("%s", out)
 	}
 	return nil
 }

--- a/pkg/roachprod/install/install.go
+++ b/pkg/roachprod/install/install.go
@@ -165,7 +165,7 @@ func Install(ctx context.Context, l *logger.Logger, c *SyncedCluster, args []str
 		var buf bytes.Buffer
 		err := c.Run(ctx, l, &buf, &buf, c.Nodes, "installing "+title, cmd)
 		if err != nil {
-			l.Printf(buf.String())
+			l.Printf("%s", buf.String())
 		}
 		return err
 	}

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -218,8 +218,7 @@ func serverError(ctx context.Context, err error) error {
 	// Include the PGCode in the message for easier troubleshooting
 	errCode := pgerror.GetPGCode(err).String()
 	if errCode != pgcode.Uncategorized.String() {
-		errMessage := fmt.Sprintf("%s Error Code: %s", errAPIInternalErrorString, errCode)
-		return status.Errorf(codes.Internal, errMessage)
+		return status.Errorf(codes.Internal, "%s Error Code: %s", errAPIInternalErrorString, errCode)
 	}
 
 	// The error is already grpcstatus formatted error.

--- a/pkg/server/api_v2_error.go
+++ b/pkg/server/api_v2_error.go
@@ -23,6 +23,7 @@ var errAPIInternalErrorString = "An internal server error has occurred. Please c
 
 var errAPIInternalError = status.Errorf(
 	codes.Internal,
+	"%s",
 	errAPIInternalErrorString,
 )
 

--- a/pkg/server/decommission.go
+++ b/pkg/server/decommission.go
@@ -175,7 +175,7 @@ func (s *Server) Decommission(
 				return grpcstatus.Error(codes.NotFound, liveness.ErrMissingRecord.Error())
 			}
 			log.Errorf(ctx, "%+s", err)
-			return grpcstatus.Errorf(codes.Internal, err.Error())
+			return grpcstatus.Errorf(codes.Internal, "%s", err.Error())
 		}
 		if statusChanged {
 			nodeDetails.TargetNodeID = int32(nodeID)

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -75,7 +75,7 @@ func (s *adminServer) Drain(req *serverpb.DrainRequest, stream serverpb.Admin_Dr
 	// Which node is this request for?
 	nodeID, local, err := s.server.status.parseNodeID(req.NodeId)
 	if err != nil {
-		return status.Errorf(codes.InvalidArgument, err.Error())
+		return status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 	if !local {
 		// This request is for another node. Forward it.

--- a/pkg/server/problem_ranges.go
+++ b/pkg/server/problem_ranges.go
@@ -37,7 +37,7 @@ func (s *statusServer) ProblemRanges(
 	if len(req.NodeID) > 0 {
 		requestedNodeID, _, err := s.parseNodeID(req.NodeID)
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, err.Error())
+			return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 		}
 		isLiveMap = liveness.IsLiveMap{
 			requestedNodeID: liveness.IsLiveMapEntry{IsLive: true},
@@ -76,7 +76,7 @@ func (s *statusServer) ProblemRanges(
 					// Context completed, response no longer needed.
 				}
 			}); err != nil {
-			return nil, status.Errorf(codes.Internal, err.Error())
+			return nil, status.Errorf(codes.Internal, "%s", err.Error())
 		}
 	}
 
@@ -145,7 +145,7 @@ func (s *statusServer) ProblemRanges(
 			sort.Sort(roachpb.RangeIDSlice(problems.CircuitBreakerErrorRangeIDs))
 			response.ProblemsByNodeID[resp.nodeID] = problems
 		case <-ctx.Done():
-			return nil, status.Errorf(codes.DeadlineExceeded, ctx.Err().Error())
+			return nil, status.Errorf(codes.DeadlineExceeded, "%s", ctx.Err().Error())
 		}
 	}
 

--- a/pkg/server/sql_stats.go
+++ b/pkg/server/sql_stats.go
@@ -52,7 +52,7 @@ func (s *statusServer) ResetSQLStats(
 	if len(req.NodeID) > 0 {
 		requestedNodeID, local, err := s.parseNodeID(req.NodeID)
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, err.Error())
+			return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 		}
 		if local {
 			controller.ResetLocalSQLStats(ctx)

--- a/pkg/server/statements.go
+++ b/pkg/server/statements.go
@@ -57,7 +57,7 @@ func (s *statusServer) Statements(
 	if len(req.NodeID) > 0 {
 		requestedNodeID, local, err := s.parseNodeID(req.NodeID)
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, err.Error())
+			return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 		}
 		if local {
 			return statementsLocal(

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -597,7 +597,7 @@ func (s *statusServer) Gossip(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if local {
@@ -625,7 +625,7 @@ func (s *statusServer) EngineStats(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if !local {
@@ -668,7 +668,7 @@ func (s *statusServer) Allocator(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if !local {
@@ -851,7 +851,7 @@ func (s *statusServer) Certificates(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if s.cfg.Insecure {
@@ -972,7 +972,7 @@ func (s *statusServer) Details(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
@@ -1013,7 +1013,7 @@ func (s *statusServer) GetFiles(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
@@ -1069,7 +1069,7 @@ func (s *statusServer) LogFilesList(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
@@ -1104,7 +1104,7 @@ func (s *statusServer) LogFile(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
@@ -1192,7 +1192,7 @@ func (s *statusServer) Logs(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
@@ -1265,7 +1265,7 @@ func (s *statusServer) Stacks(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if !local {
@@ -1298,7 +1298,7 @@ func (s *statusServer) Profile(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if !local {
@@ -1673,7 +1673,7 @@ func (s *statusServer) nodeStatus(
 ) (*statuspb.NodeStatus, error) {
 	nodeID, _, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	key := keys.NodeStatusKey(nodeID)
@@ -1723,7 +1723,7 @@ func (s *statusServer) Metrics(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if !local {
@@ -1876,7 +1876,7 @@ func (s *statusServer) rangesHelper(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, 0, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, 0, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if !local {
@@ -2048,7 +2048,7 @@ func (s *statusServer) rangesHelper(
 		return nil
 	})
 	if err != nil {
-		return nil, 0, status.Errorf(codes.Internal, err.Error())
+		return nil, 0, status.Errorf(codes.Internal, "%s", err.Error())
 	}
 	var next int
 	if len(req.RangeIDs) > 0 {
@@ -2116,7 +2116,7 @@ func (s *statusServer) TenantRanges(
 		nodeIDString := nodeID.String()
 		_, local, err := s.parseNodeID(nodeIDString)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, err.Error())
+			return nil, status.Errorf(codes.Internal, "%s", err.Error())
 		}
 
 		req := &serverpb.RangesRequest{
@@ -2225,7 +2225,7 @@ func (s *statusServer) HotRanges(
 	if len(req.NodeID) > 0 {
 		requestedNodeID, local, err := s.parseNodeID(req.NodeID)
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, err.Error())
+			return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 		}
 
 		// Only hot ranges from the local node.
@@ -2773,7 +2773,7 @@ func (s *statusServer) CancelSession(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if !local {
@@ -2786,7 +2786,7 @@ func (s *statusServer) CancelSession(
 
 	reqUsername, err := security.MakeSQLUsernameFromPreNormalizedStringChecked(req.Username)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if err := s.checkCancelPrivilege(ctx, reqUsername, findSessionBySessionID(req.SessionID)); err != nil {
@@ -2809,7 +2809,7 @@ func (s *statusServer) CancelQuery(
 ) (*serverpb.CancelQueryResponse, error) {
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 	if !local {
 		// This request needs to be forwarded to another node.
@@ -2824,7 +2824,7 @@ func (s *statusServer) CancelQuery(
 
 	reqUsername, err := security.MakeSQLUsernameFromPreNormalizedStringChecked(req.Username)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if err := s.checkCancelPrivilege(ctx, reqUsername, findSessionByQueryID(req.QueryID)); err != nil {
@@ -3050,7 +3050,7 @@ func (s *statusServer) SpanStats(
 
 	nodeID, local, err := s.parseNodeID(req.NodeID)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if !local {
@@ -3087,7 +3087,7 @@ func (s *statusServer) Diagnostics(
 	ctx = s.AnnotateCtx(ctx)
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if !local {
@@ -3116,7 +3116,7 @@ func (s *statusServer) Stores(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if !local {
@@ -3266,7 +3266,7 @@ func (s *statusServer) JobRegistryStatus(
 
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
@@ -3334,7 +3334,7 @@ func (s *statusServer) TxnIDResolution(
 
 	requestedNodeID, local, err := s.parseNodeID(req.CoordinatorID)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 	if local {
 		return s.localTxnIDResolution(req), nil
@@ -3378,7 +3378,7 @@ func (s *statusServer) TransactionContentionEvents(
 	if len(req.NodeID) > 0 {
 		requestedNodeID, local, err := s.parseNodeID(req.NodeID)
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, err.Error())
+			return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 		}
 		if local {
 			return s.localTransactionContentionEvents(shouldRedactContendingKey), nil

--- a/pkg/server/status_local_file_retrieval.go
+++ b/pkg/server/status_local_file_retrieval.go
@@ -71,7 +71,7 @@ func profileLocal(
 		}
 		var buf bytes.Buffer
 		if err := p.WriteTo(&buf, 0); err != nil {
-			return nil, status.Errorf(codes.Internal, err.Error())
+			return nil, status.Errorf(codes.Internal, "%s", err.Error())
 		}
 		return &serverpb.JSONResponse{Data: buf.Bytes()}, nil
 	}
@@ -119,7 +119,7 @@ func getLocalFiles(
 	var resp serverpb.GetFilesResponse
 	for _, pattern := range req.Patterns {
 		if err := checkFilePattern(pattern); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, err.Error())
+			return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 		}
 		filepaths, err := filepath.Glob(filepath.Join(dir, pattern))
 		if err != nil {
@@ -132,7 +132,7 @@ func getLocalFiles(
 			if !req.ListOnly {
 				contents, err = ioutil.ReadFile(path)
 				if err != nil {
-					return nil, status.Errorf(codes.Internal, err.Error())
+					return nil, status.Errorf(codes.Internal, "%s", err.Error())
 				}
 			}
 			resp.Files = append(resp.Files,

--- a/pkg/server/tenant_admin.go
+++ b/pkg/server/tenant_admin.go
@@ -125,7 +125,7 @@ func (t *tenantAdminServer) Drain(
 	// Which node is this request for?
 	parsedInstanceID, local, err := t.status.parseInstanceID(req.NodeId)
 	if err != nil {
-		return status.Errorf(codes.InvalidArgument, err.Error())
+		return status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 	if !local {
 		instance, err := t.sqlServer.sqlInstanceProvider.GetInstance(ctx, parsedInstanceID)

--- a/pkg/server/tenant_status.go
+++ b/pkg/server/tenant_status.go
@@ -432,7 +432,7 @@ func (t *tenantStatusServer) ResetSQLStats(
 	if len(req.NodeID) > 0 {
 		parsedInstanceID, local, err := t.parseInstanceID(req.NodeID)
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, err.Error())
+			return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 		}
 		if local {
 			controller.ResetLocalSQLStats(ctx)
@@ -559,7 +559,7 @@ func (t *tenantStatusServer) Statements(
 		// we are executing in the context of a tenant.
 		parsedInstanceID, local, err := t.parseInstanceID(req.NodeID)
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, err.Error())
+			return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 		}
 		if local {
 			return statementsLocal(
@@ -775,7 +775,7 @@ func (t *tenantStatusServer) Profile(
 
 	instanceID, local, err := t.parseInstanceID(request.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 	if !local {
 		instance, err := t.sqlServer.sqlInstanceProvider.GetInstance(ctx, instanceID)
@@ -808,7 +808,7 @@ func (t *tenantStatusServer) Stacks(
 
 	instanceID, local, err := t.parseInstanceID(request.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 	if !local {
 		instance, err := t.sqlServer.sqlInstanceProvider.GetInstance(ctx, instanceID)
@@ -1003,7 +1003,7 @@ func (t *tenantStatusServer) Details(
 
 	instanceID, local, err := t.parseInstanceID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 	if !local {
 		instance, err := t.sqlServer.sqlInstanceProvider.GetInstance(ctx, instanceID)
@@ -1067,7 +1067,7 @@ func (t *tenantStatusServer) TxnIDResolution(
 
 	instanceID, local, err := t.parseInstanceID(req.CoordinatorID)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 	if local {
 		return t.localTxnIDResolution(req), nil
@@ -1112,7 +1112,7 @@ func (t *tenantStatusServer) GetFiles(
 
 	instanceID, local, err := t.parseInstanceID(req.NodeId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 	if !local {
 		instance, err := t.sqlServer.sqlInstanceProvider.GetInstance(ctx, instanceID)

--- a/pkg/sql/compact_sql_stats.go
+++ b/pkg/sql/compact_sql_stats.go
@@ -227,7 +227,7 @@ func (e *scheduledSQLStatsCompactionExecutor) NotifyJobTermination(
 		e.metrics.NumSucceeded.Inc(1)
 	}
 
-	sj.SetScheduleStatus(string(jobStatus))
+	sj.SetScheduleStatus("%s", string(jobStatus))
 
 	return nil
 }

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -475,7 +475,7 @@ func (ex *connExecutor) execBind(
 	}
 
 	if log.V(2) {
-		log.Infof(ctx, "portal: %q for %q, args %q, formats %q",
+		log.Infof(ctx, "portal: %q for %v, args %q, formats %q",
 			portalName, ps.Statement, qargs, columnFormatCodes)
 	}
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -860,7 +860,7 @@ func ResolveFK(
 	}
 	if target.ParentID != tbl.ParentID {
 		if !allowCrossDatabaseFKs.Get(&evalCtx.Settings.SV) {
-			return errors.WithHintf(
+			return errors.WithHint(
 				pgerror.Newf(pgcode.InvalidForeignKey,
 					"foreign references between databases are not allowed (see the '%s' cluster setting)",
 					allowCrossDatabaseFKsSetting),

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -90,7 +90,7 @@ func (n *createViewNode) startExec(params runParams) error {
 	if !allowCrossDatabaseViews.Get(&params.p.execCfg.Settings.SV) {
 		for _, dep := range n.planDeps {
 			if dbID := dep.desc.GetParentID(); dbID != n.dbDesc.GetID() && dbID != keys.SystemDatabaseID {
-				return errors.WithHintf(
+				return errors.WithHint(
 					pgerror.Newf(pgcode.FeatureNotSupported,
 						"the view cannot refer to other databases; (see the '%s' cluster setting)",
 						allowCrossDatabaseViewsSetting),

--- a/pkg/sql/doctor/doctor.go
+++ b/pkg/sql/doctor/doctor.go
@@ -203,7 +203,7 @@ func ExamineDescriptors(
 		err := cb.ValidateNamespaceEntry(row)
 		if err != nil {
 			problemsFound = true
-			nsReport(stdout, row, err.Error())
+			nsReport(stdout, row, "%s", err.Error())
 		} else if verbose {
 			nsReport(stdout, row, "processed")
 		}

--- a/pkg/sql/importer/read_import_mysql.go
+++ b/pkg/sql/importer/read_import_mysql.go
@@ -277,7 +277,7 @@ func mysqlValueToDatum(
 			// TODO(dt): do we want to use this hint to change our decoding logic?
 			return mysqlValueToDatum(v.Expr, desired, evalContext)
 		default:
-			return nil, errors.Errorf("unexpected operator: %q", v.Operator)
+			return nil, errors.Errorf("unexpected operator: %+v", v.Operator)
 		}
 
 	case *mysql.NullVal:

--- a/pkg/sql/importer/read_import_mysql_test.go
+++ b/pkg/sql/importer/read_import_mysql_test.go
@@ -95,7 +95,7 @@ func TestMysqldumpDataReader(t *testing.T) {
 		}
 		if expected.s != injectNull {
 			if actual := *row[1].(*tree.DString); expected.s != string(actual) {
-				t.Fatalf("row %d: expected s = %q, got %q", i, expected.i, actual)
+				t.Fatalf("row %d: expected s = %q, got %q", i, expected.s, actual)
 			}
 		} else if row[1] != tree.DNull {
 			t.Fatalf("row %d: expected b = NULL, got %T: %v", i, row[1], row[1])

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1043,7 +1043,7 @@ func (f *ExprFmtCtx) scalarPropsStrings(scalar opt.ScalarExpr) []string {
 				emitProp("outer=%s", scalarProps.OuterCols)
 			}
 			if !scalarProps.VolatilitySet.IsLeakProof() {
-				emitProp(scalarProps.VolatilitySet.String())
+				emitProp("%s", scalarProps.VolatilitySet.String())
 			}
 			if scalarProps.HasCorrelatedSubquery {
 				emitProp("correlated-subquery")

--- a/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
@@ -895,7 +895,7 @@ func (g *newRuleGen) genBoundStatements(e lang.Expr) {
 // that genNestedExpr can generate references to those statements.
 func (g *newRuleGen) genNestedExpr(e lang.Expr) {
 	if label, ok := g.boundStmts[e]; ok {
-		g.w.write(label)
+		g.w.write("%s", label)
 		return
 	}
 
@@ -916,10 +916,10 @@ func (g *newRuleGen) genNestedExpr(e lang.Expr) {
 			// untyped version.
 			varName = typed
 		}
-		g.w.write(varName)
+		g.w.write("%s", varName)
 
 	case *lang.LetExpr:
-		g.w.write(string(t.Result.Label))
+		g.w.write("%s", string(t.Result.Label))
 
 	case *lang.StringExpr:
 		// Literal string expressions construct DString datums.

--- a/pkg/sql/opt/testutils/opttester/reorder_joins.go
+++ b/pkg/sql/opt/testutils/opttester/reorder_joins.go
@@ -57,11 +57,11 @@ func (ot *OptTester) ReorderJoins() (string, error) {
 			if treeNum > 1 {
 				// This isn't the first Reorder call. Output the number of joins added to
 				// the memo by the last call to Reorder.
-				ot.output(fmt.Sprintf("Joins Considered: %v\n", joinsConsidered))
+				ot.output("Joins Considered: %v\n", joinsConsidered)
 				joinsConsidered = 0
 			}
 			ot.separator("-")
-			ot.output(fmt.Sprintf("Join Tree #%d\n", treeNum))
+			ot.output("Join Tree #%d\n", treeNum)
 			ot.separator("-")
 			ot.indent(o.FormatExpr(join, memo.ExprFmtHideAll))
 			ot.output("Vertexes\n")
@@ -79,7 +79,7 @@ func (ot *OptTester) ReorderJoins() (string, error) {
 	o.JoinOrderBuilder().NotifyOnAddJoin(func(left, right, all, refs []memo.RelExpr, op opt.Operator) {
 		relsToJoin := jof.formatVertexSet(all)
 		if relsToJoin != relsJoinedLast {
-			ot.output(fmt.Sprintf("Joining %s\n", relsToJoin))
+			ot.output("Joining %s\n", relsToJoin)
 			relsJoinedLast = relsToJoin
 		}
 		ot.indent(
@@ -98,11 +98,11 @@ func (ot *OptTester) ReorderJoins() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ot.output(fmt.Sprintf("Joins Considered: %d\n", joinsConsidered))
+	ot.output("Joins Considered: %d\n", joinsConsidered)
 	ot.separator("=")
 	ot.output("Final Plan\n")
 	ot.separator("=")
-	ot.output(ot.FormatExpr(expr))
+	ot.output("%s", ot.FormatExpr(expr))
 	return ot.builder.String(), err
 }
 

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -332,7 +332,7 @@ func (n *renameTableNode) checkForCrossDbReferences(
 			return nil
 		}
 
-		return errors.WithHintf(
+		return errors.WithHint(
 			pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 				"a foreign key constraint %q will exist between databases after rename "+
 					"(see the '%s' cluster setting)",
@@ -369,7 +369,7 @@ func (n *renameTableNode) checkForCrossDbReferences(
 			switch {
 			case dependentObject.IsView():
 				if !allowCrossDatabaseViews.Get(&p.execCfg.Settings.SV) {
-					return errors.WithHintf(
+					return errors.WithHint(
 						pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 							"a view %q reference to this table will refer to another databases after rename "+
 								"(see the '%s' cluster setting)",
@@ -380,7 +380,7 @@ func (n *renameTableNode) checkForCrossDbReferences(
 				}
 			case dependentObject.IsSequence() && depType == owner:
 				if !allowCrossDatabaseSeqOwner.Get(&p.execCfg.Settings.SV) {
-					return errors.WithHintf(
+					return errors.WithHint(
 						pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 							"a sequence %q will be OWNED BY a table in a different database after rename "+
 								"(see the '%s' cluster setting)",
@@ -391,7 +391,7 @@ func (n *renameTableNode) checkForCrossDbReferences(
 				}
 			case dependentObject.IsSequence() && depType == reference:
 				if !allowCrossDatabaseSeqReferences.Get(&p.execCfg.Settings.SV) {
-					return errors.WithHintf(
+					return errors.WithHint(
 						pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 							"a sequence %q will be referenced by a table in a different database after rename "+
 								"(see the '%s' cluster setting)",
@@ -405,7 +405,7 @@ func (n *renameTableNode) checkForCrossDbReferences(
 			if !allowCrossDatabaseViews.Get(&p.execCfg.Settings.SV) {
 				// For view's dependent objects can only be
 				// relations.
-				return errors.WithHintf(
+				return errors.WithHint(
 					pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 						"this view will reference a table %q in another databases after rename "+
 							"(see the '%s' cluster setting)",
@@ -418,7 +418,7 @@ func (n *renameTableNode) checkForCrossDbReferences(
 			if !allowCrossDatabaseSeqReferences.Get(&p.execCfg.Settings.SV) {
 				// For sequences dependent references can only be
 				// a relations.
-				return errors.WithHintf(
+				return errors.WithHint(
 					pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 						"this sequence will be referenced by a table %q in a different database after rename "+
 							"(see the '%s' cluster setting)",
@@ -431,7 +431,7 @@ func (n *renameTableNode) checkForCrossDbReferences(
 			if !allowCrossDatabaseSeqOwner.Get(&p.execCfg.Settings.SV) {
 				// For sequences dependent owners can only be
 				// a relations.
-				return errors.WithHintf(
+				return errors.WithHint(
 					pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 						"this sequence will be OWNED BY a table %q in a different database after rename "+
 							"(see the '%s' cluster setting)",
@@ -461,7 +461,7 @@ func (n *renameTableNode) checkForCrossDbReferences(
 		if dependentObject.GetParentID() == targetDbDesc.GetID() {
 			return nil
 		}
-		return errors.WithHintf(
+		return errors.WithHint(
 			pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 				"this view will reference a type %q in another databases after rename "+
 					"(see the '%s' cluster setting)",

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -590,7 +590,7 @@ func assignSequenceOptions(
 				}
 				if tableDesc.ParentID != sequenceParentID &&
 					!allowCrossDatabaseSeqOwner.Get(&p.execCfg.Settings.SV) {
-					return errors.WithHintf(
+					return errors.WithHint(
 						pgerror.Newf(pgcode.FeatureNotSupported,
 							"OWNED BY cannot refer to other databases; (see the '%s' cluster setting)",
 							allowCrossDatabaseSeqOwnerSetting),
@@ -804,7 +804,7 @@ func maybeAddSequenceDependencies(
 		// Check if this reference is cross DB.
 		if seqDesc.GetParentID() != tableDesc.GetParentID() &&
 			!allowCrossDatabaseSeqReferences.Get(&st.SV) {
-			return nil, errors.WithHintf(
+			return nil, errors.WithHint(
 				pgerror.Newf(pgcode.FeatureNotSupported,
 					"sequence references cannot come from other databases; (see the '%s' cluster setting)",
 					allowCrossDatabaseSeqReferencesSetting),

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -632,14 +632,14 @@ func toSettingString(
 			if ok {
 				return settings.EncodeInt(v), nil
 			}
-			return "", errors.WithHintf(errors.Errorf("invalid integer value '%d' for enum setting", *i), setting.GetAvailableValuesAsHint())
+			return "", errors.WithHint(errors.Errorf("invalid integer value '%d' for enum setting", *i), setting.GetAvailableValuesAsHint())
 		} else if s, ok := d.(*tree.DString); ok {
 			str := string(*s)
 			v, ok := setting.ParseEnum(str)
 			if ok {
 				return settings.EncodeInt(v), nil
 			}
-			return "", errors.WithHintf(errors.Errorf("invalid string value '%s' for enum setting", str), setting.GetAvailableValuesAsHint())
+			return "", errors.WithHint(errors.Errorf("invalid string value '%s' for enum setting", str), setting.GetAvailableValuesAsHint())
 		}
 		return "", errors.Errorf("cannot use %s %T value for enum setting, must be int or string", d.ResolvedType(), d)
 	case *settings.ByteSizeSetting:

--- a/pkg/sql/ttl/ttlschedule/ttlschedule.go
+++ b/pkg/sql/ttl/ttlschedule/ttlschedule.go
@@ -180,7 +180,7 @@ func (s rowLevelTTLExecutor) NotifyJobTermination(
 		s.metrics.NumSucceeded.Inc(1)
 	}
 
-	sj.SetScheduleStatus(string(jobStatus))
+	sj.SetScheduleStatus("%s", string(jobStatus))
 	return nil
 }
 

--- a/pkg/testutils/lint/passes/errcmp/errcmp.go
+++ b/pkg/testutils/lint/passes/errcmp/errcmp.go
@@ -79,7 +79,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 func checkErrSwitch(pass *analysis.Pass, s *ast.SwitchStmt) {
 	if pass.TypesInfo.Types[s.Tag].Type == errorType {
-		pass.Reportf(s.Switch, escNl(`invalid direct comparison of error object
+		pass.Reportf(s.Switch, "%s", escNl(`invalid direct comparison of error object
 Tip:
    switch err { case errRef:...
 -> switch { case errors.Is(err, errRef): ...
@@ -89,7 +89,7 @@ Tip:
 
 func checkErrCast(pass *analysis.Pass, texpr *ast.TypeAssertExpr) {
 	if pass.TypesInfo.Types[texpr.X].Type == errorType {
-		pass.Reportf(texpr.Lparen, escNl(`invalid direct cast on error object
+		pass.Reportf(texpr.Lparen, "%s", escNl(`invalid direct cast on error object
 Alternatives:
    if _, ok := err.(*T); ok        ->   if errors.HasType(err, (*T)(nil))
    if _, ok := err.(I); ok         ->   if errors.HasInterface(err, (*I)(nil))
@@ -124,7 +124,7 @@ func checkErrCmp(pass *analysis.Pass, binaryExpr *ast.BinaryExpr) {
 				return
 			}
 
-			pass.Reportf(binaryExpr.OpPos, escNl(`use errors.Is instead of a direct comparison
+			pass.Reportf(binaryExpr.OpPos, "%s", escNl(`use errors.Is instead of a direct comparison
 For example:
    if errors.Is(err, errMyOwnErrReference) {
      ...

--- a/pkg/testutils/lint/passes/nilness/nilness.go
+++ b/pkg/testutils/lint/passes/nilness/nilness.go
@@ -148,14 +148,14 @@ func (a *analyzerConfig) runFunc(pass *analysis.Pass, fn *ssa.Function) {
 	// notNil reports an error if v is provably nil.
 	notNil := func(stack []fact, instr ssa.Instruction, v ssa.Value, descr string) {
 		if nilnessOf(stack, v) == isnil {
-			reportf("nilderef", instr.Pos(), "nil dereference in "+descr)
+			reportf("nilderef", instr.Pos(), "nil dereference in %s", descr)
 		}
 	}
 
 	// notNilArg reports an error if v is provably nil.
 	notNilArg := func(stack []fact, instr ssa.Instruction, v ssa.Value, descr string) {
 		if nilnessOf(stack, v) == isnil {
-			reportf("nilarg", instr.Pos(), "nil argument to "+descr)
+			reportf("nilarg", instr.Pos(), "nil argument to %s", descr)
 		}
 	}
 

--- a/pkg/util/grpcutil/grpc_log.go
+++ b/pkg/util/grpcutil/grpc_log.go
@@ -12,6 +12,7 @@ package grpcutil
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"os"
 	"regexp"
@@ -136,14 +137,14 @@ func (l *grpcLogger) Info(args ...interface{}) {
 	if !l.shouldLog(severity.INFO, depth2) {
 		return
 	}
-	log.InfofDepth(context.TODO(), depth2, "", args...)
+	log.InfofDepth(context.TODO(), depth2, "%s", fmt.Sprint(args...))
 }
 
 func (l *grpcLogger) Infoln(args ...interface{}) {
 	if !l.shouldLog(severity.INFO, depth2) {
 		return
 	}
-	log.InfofDepth(context.TODO(), depth2, "", args...)
+	log.InfofDepth(context.TODO(), depth2, "%s\n", fmt.Sprint(args...))
 }
 
 func (l *grpcLogger) Infof(format string, args ...interface{}) {
@@ -160,14 +161,14 @@ func (l *grpcLogger) Warning(args ...interface{}) {
 	if !l.shouldPrintWarning(depth2, args...) {
 		return
 	}
-	log.WarningfDepth(context.TODO(), depth2, "", args...)
+	log.WarningfDepth(context.TODO(), depth2, "%s", fmt.Sprint(args...))
 }
 
 func (l *grpcLogger) Warningln(args ...interface{}) {
 	if !l.shouldLog(severity.WARNING, depth2) {
 		return
 	}
-	log.WarningfDepth(context.TODO(), depth2, "", args...)
+	log.WarningfDepth(context.TODO(), depth2, "%s\n", fmt.Sprint(args...))
 }
 
 func (l *grpcLogger) Warningf(format string, args ...interface{}) {
@@ -181,14 +182,14 @@ func (l *grpcLogger) Error(args ...interface{}) {
 	if !l.shouldLog(severity.ERROR, depth2) {
 		return
 	}
-	log.ErrorfDepth(context.TODO(), depth2, "", args...)
+	log.ErrorfDepth(context.TODO(), depth2, "%s", fmt.Sprint(args...))
 }
 
 func (l *grpcLogger) Errorln(args ...interface{}) {
 	if !l.shouldLog(severity.ERROR, depth2) {
 		return
 	}
-	log.ErrorfDepth(context.TODO(), depth2, "", args...)
+	log.ErrorfDepth(context.TODO(), depth2, "%s\n", fmt.Sprint(args...))
 }
 
 func (l *grpcLogger) Errorf(format string, args ...interface{}) {
@@ -199,11 +200,11 @@ func (l *grpcLogger) Errorf(format string, args ...interface{}) {
 }
 
 func (l *grpcLogger) Fatal(args ...interface{}) {
-	log.FatalfDepth(context.TODO(), depth2, "", args...)
+	log.FatalfDepth(context.TODO(), depth2, "%s", fmt.Sprint(args...))
 }
 
 func (l *grpcLogger) Fatalln(args ...interface{}) {
-	log.FatalfDepth(context.TODO(), depth2, "", args...)
+	log.FatalfDepth(context.TODO(), depth2, "%s\n", fmt.Sprint(args...))
 }
 
 func (l *grpcLogger) Fatalf(format string, args ...interface{}) {

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -333,7 +333,7 @@ func TestListLogFiles(t *testing.T) {
 		}
 	}
 	if !foundExpected {
-		t.Fatalf("unexpected results: %q", results)
+		t.Fatalf("unexpected results: %v", results)
 	}
 }
 
@@ -369,7 +369,7 @@ func TestFilePermissions(t *testing.T) {
 		}
 	}
 	if !foundExpected {
-		t.Fatalf("unexpected results: %q", results)
+		t.Fatalf("unexpected results: %v", results)
 	}
 }
 

--- a/pkg/util/log/gen/main.go
+++ b/pkg/util/log/gen/main.go
@@ -316,7 +316,7 @@ func (logger{{.Name}}) V{{with $sev}}{{.Name}}{{end}}f(ctx context.Context, leve
 //
 {{with $sev}}{{.Comment}}{{end -}}
 func (logger{{.Name}}) {{with $sev}}{{.Name}}{{end}}(ctx context.Context, msg string) {
-  logfDepth(ctx, 1, severity.{{with $sev}}{{.NAME}}{{end}}, channel.{{.NAME}}, msg)
+  logfDepth(ctx, 1, severity.{{with $sev}}{{.NAME}}{{end}}, channel.{{.NAME}}, "%s", msg)
 }
 
 // {{with $sev}}{{.Name}}{{end}}fDepth logs to the {{.NAME}} channel with severity {{with $sev}}{{.NAME}}{{end}},
@@ -366,7 +366,7 @@ func V{{with $sev}}{{.Name}}{{end}}f(ctx context.Context, level Level, format st
 //
 {{with $sev}}{{.Comment}}{{end -}}
 func {{with $sev}}{{.Name}}{{end}}(ctx context.Context, msg string) {
-  logfDepth(ctx, 1, severity.{{with $sev}}{{.NAME}}{{end}}, channel.{{.NAME}}, msg)
+  logfDepth(ctx, 1, severity.{{with $sev}}{{.NAME}}{{end}}, channel.{{.NAME}}, "%s", msg)
 }
 
 // {{with $sev}}{{.Name}}{{end}}fDepth logs to the {{.NAME}} channel with severity {{with $sev}}{{.NAME}}{{end}},
@@ -389,7 +389,7 @@ func {{with $sev}}{{.Name}}{{end}}fDepth(ctx context.Context, depth int, format 
 //
 {{.Comment -}}
 func (logger{{.Name}}) Shout(ctx context.Context, sev Severity, msg string) {
-  shoutfDepth(ctx, 1, sev, channel.{{.NAME}}, msg)
+  shoutfDepth(ctx, 1, sev, channel.{{.NAME}}, "%s", msg)
 }
 
 // Shoutf logs to channel {{.NAME}}, and also to the real stderr if
@@ -408,7 +408,7 @@ func (logger{{.Name}}) Shoutf(ctx context.Context, sev Severity, format string, 
 //
 {{.Comment -}}
 func Shout(ctx context.Context, sev Severity, msg string) {
-  shoutfDepth(ctx, 1, sev, channel.{{.NAME}}, msg)
+  shoutfDepth(ctx, 1, sev, channel.{{.NAME}}, "%s", msg)
 }
 
 // Shoutf logs to channel {{.NAME}}, and also to the real stderr if

--- a/pkg/util/log/log_channels_generated.go
+++ b/pkg/util/log/log_channels_generated.go
@@ -213,7 +213,7 @@ func (loggerDev) VInfof(ctx context.Context, level Level, format string, args ..
 // The `INFO` severity is used for informational messages that do not
 // require action.
 func (loggerDev) Info(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.INFO, channel.DEV, msg)
+	logfDepth(ctx, 1, severity.INFO, channel.DEV, "%s", msg)
 }
 
 // InfofDepth logs to the DEV channel with severity INFO,
@@ -306,7 +306,7 @@ func VInfof(ctx context.Context, level Level, format string, args ...interface{}
 // The `INFO` severity is used for informational messages that do not
 // require action.
 func Info(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.INFO, channel.DEV, msg)
+	logfDepth(ctx, 1, severity.INFO, channel.DEV, "%s", msg)
 }
 
 // InfofDepth logs to the DEV channel with severity INFO,
@@ -399,7 +399,7 @@ func (loggerDev) VWarningf(ctx context.Context, level Level, format string, args
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 func (loggerDev) Warning(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.WARNING, channel.DEV, msg)
+	logfDepth(ctx, 1, severity.WARNING, channel.DEV, "%s", msg)
 }
 
 // WarningfDepth logs to the DEV channel with severity WARNING,
@@ -492,7 +492,7 @@ func VWarningf(ctx context.Context, level Level, format string, args ...interfac
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 func Warning(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.WARNING, channel.DEV, msg)
+	logfDepth(ctx, 1, severity.WARNING, channel.DEV, "%s", msg)
 }
 
 // WarningfDepth logs to the DEV channel with severity WARNING,
@@ -588,7 +588,7 @@ func (loggerDev) VErrorf(ctx context.Context, level Level, format string, args .
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerDev) Error(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.ERROR, channel.DEV, msg)
+	logfDepth(ctx, 1, severity.ERROR, channel.DEV, "%s", msg)
 }
 
 // ErrorfDepth logs to the DEV channel with severity ERROR,
@@ -685,7 +685,7 @@ func VErrorf(ctx context.Context, level Level, format string, args ...interface{
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func Error(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.ERROR, channel.DEV, msg)
+	logfDepth(ctx, 1, severity.ERROR, channel.DEV, "%s", msg)
 }
 
 // ErrorfDepth logs to the DEV channel with severity ERROR,
@@ -782,7 +782,7 @@ func (loggerDev) VFatalf(ctx context.Context, level Level, format string, args .
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerDev) Fatal(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.FATAL, channel.DEV, msg)
+	logfDepth(ctx, 1, severity.FATAL, channel.DEV, "%s", msg)
 }
 
 // FatalfDepth logs to the DEV channel with severity FATAL,
@@ -879,7 +879,7 @@ func VFatalf(ctx context.Context, level Level, format string, args ...interface{
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func Fatal(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.FATAL, channel.DEV, msg)
+	logfDepth(ctx, 1, severity.FATAL, channel.DEV, "%s", msg)
 }
 
 // FatalfDepth logs to the DEV channel with severity FATAL,
@@ -921,7 +921,7 @@ func FatalfDepth(ctx context.Context, depth int, format string, args ...interfac
 // sensitive operational data.
 // See [Configure logs](configure-logs.html#dev-channel).
 func (loggerDev) Shout(ctx context.Context, sev Severity, msg string) {
-	shoutfDepth(ctx, 1, sev, channel.DEV, msg)
+	shoutfDepth(ctx, 1, sev, channel.DEV, "%s", msg)
 }
 
 // Shoutf logs to channel DEV, and also to the real stderr if
@@ -958,7 +958,7 @@ func (loggerDev) Shoutf(ctx context.Context, sev Severity, format string, args .
 // sensitive operational data.
 // See [Configure logs](configure-logs.html#dev-channel).
 func Shout(ctx context.Context, sev Severity, msg string) {
-	shoutfDepth(ctx, 1, sev, channel.DEV, msg)
+	shoutfDepth(ctx, 1, sev, channel.DEV, "%s", msg)
 }
 
 // Shoutf logs to channel DEV, and also to the real stderr if
@@ -1072,7 +1072,7 @@ func (loggerOps) VInfof(ctx context.Context, level Level, format string, args ..
 // The `INFO` severity is used for informational messages that do not
 // require action.
 func (loggerOps) Info(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.INFO, channel.OPS, msg)
+	logfDepth(ctx, 1, severity.INFO, channel.OPS, "%s", msg)
 }
 
 // InfofDepth logs to the OPS channel with severity INFO,
@@ -1165,7 +1165,7 @@ func (loggerOps) VWarningf(ctx context.Context, level Level, format string, args
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 func (loggerOps) Warning(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.WARNING, channel.OPS, msg)
+	logfDepth(ctx, 1, severity.WARNING, channel.OPS, "%s", msg)
 }
 
 // WarningfDepth logs to the OPS channel with severity WARNING,
@@ -1261,7 +1261,7 @@ func (loggerOps) VErrorf(ctx context.Context, level Level, format string, args .
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerOps) Error(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.ERROR, channel.OPS, msg)
+	logfDepth(ctx, 1, severity.ERROR, channel.OPS, "%s", msg)
 }
 
 // ErrorfDepth logs to the OPS channel with severity ERROR,
@@ -1358,7 +1358,7 @@ func (loggerOps) VFatalf(ctx context.Context, level Level, format string, args .
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerOps) Fatal(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.FATAL, channel.OPS, msg)
+	logfDepth(ctx, 1, severity.FATAL, channel.OPS, "%s", msg)
 }
 
 // FatalfDepth logs to the OPS channel with severity FATAL,
@@ -1400,7 +1400,7 @@ func (loggerOps) FatalfDepth(ctx context.Context, depth int, format string, args
 // - [Cluster setting](cluster-settings.html) changes
 // - [Zone configuration](configure-replication-zones.html) changes
 func (loggerOps) Shout(ctx context.Context, sev Severity, msg string) {
-	shoutfDepth(ctx, 1, sev, channel.OPS, msg)
+	shoutfDepth(ctx, 1, sev, channel.OPS, "%s", msg)
 }
 
 // Shoutf logs to channel OPS, and also to the real stderr if
@@ -1502,7 +1502,7 @@ func (loggerHealth) VInfof(ctx context.Context, level Level, format string, args
 // The `INFO` severity is used for informational messages that do not
 // require action.
 func (loggerHealth) Info(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.INFO, channel.HEALTH, msg)
+	logfDepth(ctx, 1, severity.INFO, channel.HEALTH, "%s", msg)
 }
 
 // InfofDepth logs to the HEALTH channel with severity INFO,
@@ -1583,7 +1583,7 @@ func (loggerHealth) VWarningf(ctx context.Context, level Level, format string, a
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 func (loggerHealth) Warning(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.WARNING, channel.HEALTH, msg)
+	logfDepth(ctx, 1, severity.WARNING, channel.HEALTH, "%s", msg)
 }
 
 // WarningfDepth logs to the HEALTH channel with severity WARNING,
@@ -1667,7 +1667,7 @@ func (loggerHealth) VErrorf(ctx context.Context, level Level, format string, arg
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerHealth) Error(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.ERROR, channel.HEALTH, msg)
+	logfDepth(ctx, 1, severity.ERROR, channel.HEALTH, "%s", msg)
 }
 
 // ErrorfDepth logs to the HEALTH channel with severity ERROR,
@@ -1752,7 +1752,7 @@ func (loggerHealth) VFatalf(ctx context.Context, level Level, format string, arg
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerHealth) Fatal(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.FATAL, channel.HEALTH, msg)
+	logfDepth(ctx, 1, severity.FATAL, channel.HEALTH, "%s", msg)
 }
 
 // FatalfDepth logs to the HEALTH channel with severity FATAL,
@@ -1788,7 +1788,7 @@ func (loggerHealth) FatalfDepth(ctx context.Context, depth int, format string, a
 // - Range and table leasing events
 // - Up- and down-replication, range unavailability
 func (loggerHealth) Shout(ctx context.Context, sev Severity, msg string) {
-	shoutfDepth(ctx, 1, sev, channel.HEALTH, msg)
+	shoutfDepth(ctx, 1, sev, channel.HEALTH, "%s", msg)
 }
 
 // Shoutf logs to channel HEALTH, and also to the real stderr if
@@ -1863,7 +1863,7 @@ func (loggerStorage) VInfof(ctx context.Context, level Level, format string, arg
 // The `INFO` severity is used for informational messages that do not
 // require action.
 func (loggerStorage) Info(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.INFO, channel.STORAGE, msg)
+	logfDepth(ctx, 1, severity.INFO, channel.STORAGE, "%s", msg)
 }
 
 // InfofDepth logs to the STORAGE channel with severity INFO,
@@ -1920,7 +1920,7 @@ func (loggerStorage) VWarningf(ctx context.Context, level Level, format string, 
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 func (loggerStorage) Warning(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.WARNING, channel.STORAGE, msg)
+	logfDepth(ctx, 1, severity.WARNING, channel.STORAGE, "%s", msg)
 }
 
 // WarningfDepth logs to the STORAGE channel with severity WARNING,
@@ -1980,7 +1980,7 @@ func (loggerStorage) VErrorf(ctx context.Context, level Level, format string, ar
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerStorage) Error(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.ERROR, channel.STORAGE, msg)
+	logfDepth(ctx, 1, severity.ERROR, channel.STORAGE, "%s", msg)
 }
 
 // ErrorfDepth logs to the STORAGE channel with severity ERROR,
@@ -2041,7 +2041,7 @@ func (loggerStorage) VFatalf(ctx context.Context, level Level, format string, ar
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerStorage) Fatal(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.FATAL, channel.STORAGE, msg)
+	logfDepth(ctx, 1, severity.FATAL, channel.STORAGE, "%s", msg)
 }
 
 // FatalfDepth logs to the STORAGE channel with severity FATAL,
@@ -2065,7 +2065,7 @@ func (loggerStorage) FatalfDepth(ctx context.Context, depth int, format string, 
 // The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 func (loggerStorage) Shout(ctx context.Context, sev Severity, msg string) {
-	shoutfDepth(ctx, 1, sev, channel.STORAGE, msg)
+	shoutfDepth(ctx, 1, sev, channel.STORAGE, "%s", msg)
 }
 
 // Shoutf logs to channel STORAGE, and also to the real stderr if
@@ -2166,7 +2166,7 @@ func (loggerSessions) VInfof(ctx context.Context, level Level, format string, ar
 // The `INFO` severity is used for informational messages that do not
 // require action.
 func (loggerSessions) Info(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.INFO, channel.SESSIONS, msg)
+	logfDepth(ctx, 1, severity.INFO, channel.SESSIONS, "%s", msg)
 }
 
 // InfofDepth logs to the SESSIONS channel with severity INFO,
@@ -2255,7 +2255,7 @@ func (loggerSessions) VWarningf(ctx context.Context, level Level, format string,
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 func (loggerSessions) Warning(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.WARNING, channel.SESSIONS, msg)
+	logfDepth(ctx, 1, severity.WARNING, channel.SESSIONS, "%s", msg)
 }
 
 // WarningfDepth logs to the SESSIONS channel with severity WARNING,
@@ -2347,7 +2347,7 @@ func (loggerSessions) VErrorf(ctx context.Context, level Level, format string, a
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSessions) Error(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.ERROR, channel.SESSIONS, msg)
+	logfDepth(ctx, 1, severity.ERROR, channel.SESSIONS, "%s", msg)
 }
 
 // ErrorfDepth logs to the SESSIONS channel with severity ERROR,
@@ -2440,7 +2440,7 @@ func (loggerSessions) VFatalf(ctx context.Context, level Level, format string, a
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSessions) Fatal(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.FATAL, channel.SESSIONS, msg)
+	logfDepth(ctx, 1, severity.FATAL, channel.SESSIONS, "%s", msg)
 }
 
 // FatalfDepth logs to the SESSIONS channel with severity FATAL,
@@ -2480,7 +2480,7 @@ func (loggerSessions) FatalfDepth(ctx context.Context, depth int, format string,
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 func (loggerSessions) Shout(ctx context.Context, sev Severity, msg string) {
-	shoutfDepth(ctx, 1, sev, channel.SESSIONS, msg)
+	shoutfDepth(ctx, 1, sev, channel.SESSIONS, "%s", msg)
 }
 
 // Shoutf logs to channel SESSIONS, and also to the real stderr if
@@ -2601,7 +2601,7 @@ func (loggerSqlSchema) VInfof(ctx context.Context, level Level, format string, a
 // The `INFO` severity is used for informational messages that do not
 // require action.
 func (loggerSqlSchema) Info(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.INFO, channel.SQL_SCHEMA, msg)
+	logfDepth(ctx, 1, severity.INFO, channel.SQL_SCHEMA, "%s", msg)
 }
 
 // InfofDepth logs to the SQL_SCHEMA channel with severity INFO,
@@ -2702,7 +2702,7 @@ func (loggerSqlSchema) VWarningf(ctx context.Context, level Level, format string
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 func (loggerSqlSchema) Warning(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.WARNING, channel.SQL_SCHEMA, msg)
+	logfDepth(ctx, 1, severity.WARNING, channel.SQL_SCHEMA, "%s", msg)
 }
 
 // WarningfDepth logs to the SQL_SCHEMA channel with severity WARNING,
@@ -2806,7 +2806,7 @@ func (loggerSqlSchema) VErrorf(ctx context.Context, level Level, format string, 
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlSchema) Error(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.ERROR, channel.SQL_SCHEMA, msg)
+	logfDepth(ctx, 1, severity.ERROR, channel.SQL_SCHEMA, "%s", msg)
 }
 
 // ErrorfDepth logs to the SQL_SCHEMA channel with severity ERROR,
@@ -2911,7 +2911,7 @@ func (loggerSqlSchema) VFatalf(ctx context.Context, level Level, format string, 
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlSchema) Fatal(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.FATAL, channel.SQL_SCHEMA, msg)
+	logfDepth(ctx, 1, severity.FATAL, channel.SQL_SCHEMA, "%s", msg)
 }
 
 // FatalfDepth logs to the SQL_SCHEMA channel with severity FATAL,
@@ -2957,7 +2957,7 @@ func (loggerSqlSchema) FatalfDepth(ctx context.Context, depth int, format string
 // `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 func (loggerSqlSchema) Shout(ctx context.Context, sev Severity, msg string) {
-	shoutfDepth(ctx, 1, sev, channel.SQL_SCHEMA, msg)
+	shoutfDepth(ctx, 1, sev, channel.SQL_SCHEMA, "%s", msg)
 }
 
 // Shoutf logs to channel SQL_SCHEMA, and also to the real stderr if
@@ -3069,7 +3069,7 @@ func (loggerUserAdmin) VInfof(ctx context.Context, level Level, format string, a
 // The `INFO` severity is used for informational messages that do not
 // require action.
 func (loggerUserAdmin) Info(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.INFO, channel.USER_ADMIN, msg)
+	logfDepth(ctx, 1, severity.INFO, channel.USER_ADMIN, "%s", msg)
 }
 
 // InfofDepth logs to the USER_ADMIN channel with severity INFO,
@@ -3158,7 +3158,7 @@ func (loggerUserAdmin) VWarningf(ctx context.Context, level Level, format string
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 func (loggerUserAdmin) Warning(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.WARNING, channel.USER_ADMIN, msg)
+	logfDepth(ctx, 1, severity.WARNING, channel.USER_ADMIN, "%s", msg)
 }
 
 // WarningfDepth logs to the USER_ADMIN channel with severity WARNING,
@@ -3250,7 +3250,7 @@ func (loggerUserAdmin) VErrorf(ctx context.Context, level Level, format string, 
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerUserAdmin) Error(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.ERROR, channel.USER_ADMIN, msg)
+	logfDepth(ctx, 1, severity.ERROR, channel.USER_ADMIN, "%s", msg)
 }
 
 // ErrorfDepth logs to the USER_ADMIN channel with severity ERROR,
@@ -3343,7 +3343,7 @@ func (loggerUserAdmin) VFatalf(ctx context.Context, level Level, format string, 
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerUserAdmin) Fatal(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.FATAL, channel.USER_ADMIN, msg)
+	logfDepth(ctx, 1, severity.FATAL, channel.USER_ADMIN, "%s", msg)
 }
 
 // FatalfDepth logs to the USER_ADMIN channel with severity FATAL,
@@ -3383,7 +3383,7 @@ func (loggerUserAdmin) FatalfDepth(ctx context.Context, depth int, format string
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 func (loggerUserAdmin) Shout(ctx context.Context, sev Severity, msg string) {
-	shoutfDepth(ctx, 1, sev, channel.USER_ADMIN, msg)
+	shoutfDepth(ctx, 1, sev, channel.USER_ADMIN, "%s", msg)
 }
 
 // Shoutf logs to channel USER_ADMIN, and also to the real stderr if
@@ -3484,7 +3484,7 @@ func (loggerPrivileges) VInfof(ctx context.Context, level Level, format string, 
 // The `INFO` severity is used for informational messages that do not
 // require action.
 func (loggerPrivileges) Info(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.INFO, channel.PRIVILEGES, msg)
+	logfDepth(ctx, 1, severity.INFO, channel.PRIVILEGES, "%s", msg)
 }
 
 // InfofDepth logs to the PRIVILEGES channel with severity INFO,
@@ -3565,7 +3565,7 @@ func (loggerPrivileges) VWarningf(ctx context.Context, level Level, format strin
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 func (loggerPrivileges) Warning(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.WARNING, channel.PRIVILEGES, msg)
+	logfDepth(ctx, 1, severity.WARNING, channel.PRIVILEGES, "%s", msg)
 }
 
 // WarningfDepth logs to the PRIVILEGES channel with severity WARNING,
@@ -3649,7 +3649,7 @@ func (loggerPrivileges) VErrorf(ctx context.Context, level Level, format string,
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerPrivileges) Error(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.ERROR, channel.PRIVILEGES, msg)
+	logfDepth(ctx, 1, severity.ERROR, channel.PRIVILEGES, "%s", msg)
 }
 
 // ErrorfDepth logs to the PRIVILEGES channel with severity ERROR,
@@ -3734,7 +3734,7 @@ func (loggerPrivileges) VFatalf(ctx context.Context, level Level, format string,
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerPrivileges) Fatal(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.FATAL, channel.PRIVILEGES, msg)
+	logfDepth(ctx, 1, severity.FATAL, channel.PRIVILEGES, "%s", msg)
 }
 
 // FatalfDepth logs to the PRIVILEGES channel with severity FATAL,
@@ -3770,7 +3770,7 @@ func (loggerPrivileges) FatalfDepth(ctx context.Context, depth int, format strin
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 func (loggerPrivileges) Shout(ctx context.Context, sev Severity, msg string) {
-	shoutfDepth(ctx, 1, sev, channel.PRIVILEGES, msg)
+	shoutfDepth(ctx, 1, sev, channel.PRIVILEGES, "%s", msg)
 }
 
 // Shoutf logs to channel PRIVILEGES, and also to the real stderr if
@@ -3877,7 +3877,7 @@ func (loggerSensitiveAccess) VInfof(ctx context.Context, level Level, format str
 // The `INFO` severity is used for informational messages that do not
 // require action.
 func (loggerSensitiveAccess) Info(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.INFO, channel.SENSITIVE_ACCESS, msg)
+	logfDepth(ctx, 1, severity.INFO, channel.SENSITIVE_ACCESS, "%s", msg)
 }
 
 // InfofDepth logs to the SENSITIVE_ACCESS channel with severity INFO,
@@ -3966,7 +3966,7 @@ func (loggerSensitiveAccess) VWarningf(ctx context.Context, level Level, format 
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 func (loggerSensitiveAccess) Warning(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.WARNING, channel.SENSITIVE_ACCESS, msg)
+	logfDepth(ctx, 1, severity.WARNING, channel.SENSITIVE_ACCESS, "%s", msg)
 }
 
 // WarningfDepth logs to the SENSITIVE_ACCESS channel with severity WARNING,
@@ -4058,7 +4058,7 @@ func (loggerSensitiveAccess) VErrorf(ctx context.Context, level Level, format st
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSensitiveAccess) Error(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.ERROR, channel.SENSITIVE_ACCESS, msg)
+	logfDepth(ctx, 1, severity.ERROR, channel.SENSITIVE_ACCESS, "%s", msg)
 }
 
 // ErrorfDepth logs to the SENSITIVE_ACCESS channel with severity ERROR,
@@ -4151,7 +4151,7 @@ func (loggerSensitiveAccess) VFatalf(ctx context.Context, level Level, format st
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSensitiveAccess) Fatal(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.FATAL, channel.SENSITIVE_ACCESS, msg)
+	logfDepth(ctx, 1, severity.FATAL, channel.SENSITIVE_ACCESS, "%s", msg)
 }
 
 // FatalfDepth logs to the SENSITIVE_ACCESS channel with severity FATAL,
@@ -4191,7 +4191,7 @@ func (loggerSensitiveAccess) FatalfDepth(ctx context.Context, depth int, format 
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 func (loggerSensitiveAccess) Shout(ctx context.Context, sev Severity, msg string) {
-	shoutfDepth(ctx, 1, sev, channel.SENSITIVE_ACCESS, msg)
+	shoutfDepth(ctx, 1, sev, channel.SENSITIVE_ACCESS, "%s", msg)
 }
 
 // Shoutf logs to channel SENSITIVE_ACCESS, and also to the real stderr if
@@ -4284,7 +4284,7 @@ func (loggerSqlExec) VInfof(ctx context.Context, level Level, format string, arg
 // The `INFO` severity is used for informational messages that do not
 // require action.
 func (loggerSqlExec) Info(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.INFO, channel.SQL_EXEC, msg)
+	logfDepth(ctx, 1, severity.INFO, channel.SQL_EXEC, "%s", msg)
 }
 
 // InfofDepth logs to the SQL_EXEC channel with severity INFO,
@@ -4357,7 +4357,7 @@ func (loggerSqlExec) VWarningf(ctx context.Context, level Level, format string, 
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 func (loggerSqlExec) Warning(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.WARNING, channel.SQL_EXEC, msg)
+	logfDepth(ctx, 1, severity.WARNING, channel.SQL_EXEC, "%s", msg)
 }
 
 // WarningfDepth logs to the SQL_EXEC channel with severity WARNING,
@@ -4433,7 +4433,7 @@ func (loggerSqlExec) VErrorf(ctx context.Context, level Level, format string, ar
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlExec) Error(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.ERROR, channel.SQL_EXEC, msg)
+	logfDepth(ctx, 1, severity.ERROR, channel.SQL_EXEC, "%s", msg)
 }
 
 // ErrorfDepth logs to the SQL_EXEC channel with severity ERROR,
@@ -4510,7 +4510,7 @@ func (loggerSqlExec) VFatalf(ctx context.Context, level Level, format string, ar
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlExec) Fatal(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.FATAL, channel.SQL_EXEC, msg)
+	logfDepth(ctx, 1, severity.FATAL, channel.SQL_EXEC, "%s", msg)
 }
 
 // FatalfDepth logs to the SQL_EXEC channel with severity FATAL,
@@ -4542,7 +4542,7 @@ func (loggerSqlExec) FatalfDepth(ctx context.Context, depth int, format string, 
 //   `sql.trace.log_statement_execute` [cluster setting](cluster-settings.html))
 // - uncaught Go panic errors during the execution of a SQL statement.
 func (loggerSqlExec) Shout(ctx context.Context, sev Severity, msg string) {
-	shoutfDepth(ctx, 1, sev, channel.SQL_EXEC, msg)
+	shoutfDepth(ctx, 1, sev, channel.SQL_EXEC, "%s", msg)
 }
 
 // Shoutf logs to channel SQL_EXEC, and also to the real stderr if
@@ -4643,7 +4643,7 @@ func (loggerSqlPerf) VInfof(ctx context.Context, level Level, format string, arg
 // The `INFO` severity is used for informational messages that do not
 // require action.
 func (loggerSqlPerf) Info(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.INFO, channel.SQL_PERF, msg)
+	logfDepth(ctx, 1, severity.INFO, channel.SQL_PERF, "%s", msg)
 }
 
 // InfofDepth logs to the SQL_PERF channel with severity INFO,
@@ -4728,7 +4728,7 @@ func (loggerSqlPerf) VWarningf(ctx context.Context, level Level, format string, 
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 func (loggerSqlPerf) Warning(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.WARNING, channel.SQL_PERF, msg)
+	logfDepth(ctx, 1, severity.WARNING, channel.SQL_PERF, "%s", msg)
 }
 
 // WarningfDepth logs to the SQL_PERF channel with severity WARNING,
@@ -4816,7 +4816,7 @@ func (loggerSqlPerf) VErrorf(ctx context.Context, level Level, format string, ar
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlPerf) Error(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.ERROR, channel.SQL_PERF, msg)
+	logfDepth(ctx, 1, severity.ERROR, channel.SQL_PERF, "%s", msg)
 }
 
 // ErrorfDepth logs to the SQL_PERF channel with severity ERROR,
@@ -4905,7 +4905,7 @@ func (loggerSqlPerf) VFatalf(ctx context.Context, level Level, format string, ar
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlPerf) Fatal(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.FATAL, channel.SQL_PERF, msg)
+	logfDepth(ctx, 1, severity.FATAL, channel.SQL_PERF, "%s", msg)
 }
 
 // FatalfDepth logs to the SQL_PERF channel with severity FATAL,
@@ -4943,7 +4943,7 @@ func (loggerSqlPerf) FatalfDepth(ctx context.Context, depth int, format string, 
 // with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 func (loggerSqlPerf) Shout(ctx context.Context, sev Severity, msg string) {
-	shoutfDepth(ctx, 1, sev, channel.SQL_PERF, msg)
+	shoutfDepth(ctx, 1, sev, channel.SQL_PERF, "%s", msg)
 }
 
 // Shoutf logs to channel SQL_PERF, and also to the real stderr if
@@ -5027,7 +5027,7 @@ func (loggerSqlInternalPerf) VInfof(ctx context.Context, level Level, format str
 // The `INFO` severity is used for informational messages that do not
 // require action.
 func (loggerSqlInternalPerf) Info(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.INFO, channel.SQL_INTERNAL_PERF, msg)
+	logfDepth(ctx, 1, severity.INFO, channel.SQL_INTERNAL_PERF, "%s", msg)
 }
 
 // InfofDepth logs to the SQL_INTERNAL_PERF channel with severity INFO,
@@ -5092,7 +5092,7 @@ func (loggerSqlInternalPerf) VWarningf(ctx context.Context, level Level, format 
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 func (loggerSqlInternalPerf) Warning(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.WARNING, channel.SQL_INTERNAL_PERF, msg)
+	logfDepth(ctx, 1, severity.WARNING, channel.SQL_INTERNAL_PERF, "%s", msg)
 }
 
 // WarningfDepth logs to the SQL_INTERNAL_PERF channel with severity WARNING,
@@ -5160,7 +5160,7 @@ func (loggerSqlInternalPerf) VErrorf(ctx context.Context, level Level, format st
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerSqlInternalPerf) Error(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.ERROR, channel.SQL_INTERNAL_PERF, msg)
+	logfDepth(ctx, 1, severity.ERROR, channel.SQL_INTERNAL_PERF, "%s", msg)
 }
 
 // ErrorfDepth logs to the SQL_INTERNAL_PERF channel with severity ERROR,
@@ -5229,7 +5229,7 @@ func (loggerSqlInternalPerf) VFatalf(ctx context.Context, level Level, format st
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerSqlInternalPerf) Fatal(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.FATAL, channel.SQL_INTERNAL_PERF, msg)
+	logfDepth(ctx, 1, severity.FATAL, channel.SQL_INTERNAL_PERF, "%s", msg)
 }
 
 // FatalfDepth logs to the SQL_INTERNAL_PERF channel with severity FATAL,
@@ -5257,7 +5257,7 @@ func (loggerSqlInternalPerf) FatalfDepth(ctx context.Context, depth int, format 
 // channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 func (loggerSqlInternalPerf) Shout(ctx context.Context, sev Severity, msg string) {
-	shoutfDepth(ctx, 1, sev, channel.SQL_INTERNAL_PERF, msg)
+	shoutfDepth(ctx, 1, sev, channel.SQL_INTERNAL_PERF, "%s", msg)
 }
 
 // Shoutf logs to channel SQL_INTERNAL_PERF, and also to the real stderr if
@@ -5332,7 +5332,7 @@ func (loggerTelemetry) VInfof(ctx context.Context, level Level, format string, a
 // The `INFO` severity is used for informational messages that do not
 // require action.
 func (loggerTelemetry) Info(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.INFO, channel.TELEMETRY, msg)
+	logfDepth(ctx, 1, severity.INFO, channel.TELEMETRY, "%s", msg)
 }
 
 // InfofDepth logs to the TELEMETRY channel with severity INFO,
@@ -5393,7 +5393,7 @@ func (loggerTelemetry) VWarningf(ctx context.Context, level Level, format string
 // The `WARNING` severity is used for situations which may require special handling,
 // where normal operation is expected to resume automatically.
 func (loggerTelemetry) Warning(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.WARNING, channel.TELEMETRY, msg)
+	logfDepth(ctx, 1, severity.WARNING, channel.TELEMETRY, "%s", msg)
 }
 
 // WarningfDepth logs to the TELEMETRY channel with severity WARNING,
@@ -5457,7 +5457,7 @@ func (loggerTelemetry) VErrorf(ctx context.Context, level Level, format string, 
 // where normal operation could not proceed as expected.
 // Other operations can continue mostly unaffected.
 func (loggerTelemetry) Error(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.ERROR, channel.TELEMETRY, msg)
+	logfDepth(ctx, 1, severity.ERROR, channel.TELEMETRY, "%s", msg)
 }
 
 // ErrorfDepth logs to the TELEMETRY channel with severity ERROR,
@@ -5522,7 +5522,7 @@ func (loggerTelemetry) VFatalf(ctx context.Context, level Level, format string, 
 // server shutdown. A report is also sent to telemetry if telemetry
 // is enabled.
 func (loggerTelemetry) Fatal(ctx context.Context, msg string) {
-	logfDepth(ctx, 1, severity.FATAL, channel.TELEMETRY, msg)
+	logfDepth(ctx, 1, severity.FATAL, channel.TELEMETRY, "%s", msg)
 }
 
 // FatalfDepth logs to the TELEMETRY channel with severity FATAL,
@@ -5548,7 +5548,7 @@ func (loggerTelemetry) FatalfDepth(ctx context.Context, depth int, format string
 // feature usage within CockroachDB and anonymizes any application-
 // specific data.
 func (loggerTelemetry) Shout(ctx context.Context, sev Severity, msg string) {
-	shoutfDepth(ctx, 1, sev, channel.TELEMETRY, msg)
+	shoutfDepth(ctx, 1, sev, channel.TELEMETRY, "%s", msg)
 }
 
 // Shoutf logs to channel TELEMETRY, and also to the real stderr if

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -168,6 +168,7 @@ func Event(ctx context.Context, msg string) {
 		channel.DEV,   /* unused for trace events */
 		1,             /* depth */
 		sp.Redactable(),
+		"%s",
 		msg)
 	eventInternal(sp, el, false /* isErr */, &entry)
 }
@@ -222,7 +223,7 @@ func vEventf(
 // active trace or event log) or to the trace/event log alone, depending on
 // whether the specified verbosity level is active.
 func VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, msg)
+	vEventf(ctx, false /* isErr */, 1, level, "%s", msg)
 }
 
 // VEventf either logs a message to the DEV channel (which also outputs to the
@@ -242,7 +243,7 @@ func VEventfDepth(ctx context.Context, depth int, level Level, format string, ar
 // to the active trace or event log) or to the trace/event log alone, depending
 // on whether the specified verbosity level is active.
 func VErrEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, true /* isErr */, 1, level, msg)
+	vEventf(ctx, true /* isErr */, 1, level, "%s", msg)
 }
 
 // VErrEventf either logs an error message to the DEV Channel (which also outputs

--- a/pkg/util/metric/graphite_exporter.go
+++ b/pkg/util/metric/graphite_exporter.go
@@ -60,7 +60,7 @@ func (ge *GraphiteExporter) Push(ctx context.Context, endpoint string) error {
 		Timeout:       10 * time.Second,
 		ErrorHandling: graphite.AbortOnError,
 		Logger: loggerFunc(func(args ...interface{}) {
-			log.InfofDepth(ctx, 1, "", args...)
+			log.InfofDepth(ctx, 1, "%s", fmt.Sprint(args...))
 		}),
 	}); err != nil {
 		return err


### PR DESCRIPTION
In Go 1.24, the `printf` analyzer in `go vet` was improved to catch cases where the format string is a non-const string. This is a pretty strong code smell and I think qualifies as worth changing despite wanting to avoid code churn -- the code is fundamentally wrong.

There's a few additional cases found in newer versions of Go where the format string specifier and the type of the value being formatted don't match. These cases deserve some extra scrutiny during review, particularly since I am not fluent in Go.

This is split out from the Go 1.26 PR I'm working on, since it can be applied any time.