### PR TITLE
try using larger machines for test jobs

### DIFF
--- a/.github/buildomat/jobs/test-illumos.sh
+++ b/.github/buildomat/jobs/test-illumos.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "test-illumos"
 #: variety = "basic"
-#: target = "helios-2.0"
+#: target = "helios-2.0-16c64gb"
 
 set -o errexit
 set -o pipefail

--- a/.github/buildomat/jobs/test-linux.sh
+++ b/.github/buildomat/jobs/test-linux.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "test-linux"
 #: variety = "basic"
-#: target = "ubuntu-22.04"
+#: target = "ubuntu-22.04-large"
 
 set -o errexit
 set -o pipefail


### PR DESCRIPTION
Reduces Helios test time, ~43m -> ~31m.

This does not significantly reduce CI time on Ubuntu (~27m -> ~23m) but I am hopeful this will reduce contention-related flakes.