### PR TITLE
improve logging around unhealthy clocks

### DIFF
--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -252,6 +252,8 @@ func (r *RemoteClockMonitor) VerifyClockOffset(ctx context.Context) error {
 			offsets = append(offsets, float64(offset.Offset-offset.Uncertainty))
 			if offset.isHealthy(ctx, maxOffset) {
 				healthyOffsetCount++
+			} else {
+				log.Health.Errorf(ctx, "node %s is not healthy: clock offset is %s", addr, offset)
 			}
 		}
 		numClocks := len(r.mu.offsets)


### PR DESCRIPTION
We have seen this error

    clock synchronization error: this node is more than 500ms away from at least half of the known nodes

but when this happens it's not clear what the real issue is.  Are the clocks 501ms away? or 5000ms?

This logs an additional error any time a remote node is unhealthy

    E260312 20:20:10.978114 15 2@rpc/clock_offset.go:256  [-] 3  node 3 is not healthy: clock offset is off=91ns, err=31ns, at=1970-01-01 00:00:00 +0000 UTC