### PR TITLE
fix ui-test

### DIFF
--- a/.github/buildomat/linux-setup.sh
+++ b/.github/buildomat/linux-setup.sh
@@ -1,7 +1,7 @@
 source .github/buildomat/versions.sh
 
 sudo apt-get install -y --no-install-recommends \
-    build-essential autoconf cmake libedit-dev ncurses-dev
+    build-essential autoconf cmake libedit-dev ncurses-dev unzip
 
 pushd /work
 curl -sSfL --retry 10 -O "https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz"


### PR DESCRIPTION
`npx @puppeteer/browsers install chrome@stable` is failing with:

```
Error: All providers failed for chrome 150.0.7871.24:
  - DefaultProvider: Extraction failed: Required native binary ('tar.exe', 'powershell.exe', 'pwsh.exe' or 'unzip') was not found in the system PATH.
    at installWithProviders (file:///home/build/.npm/_npx/c99440fc2d0a3f00/node_modules/@puppeteer/browsers/lib/install.js:108:11)
    at async install (file:///home/build/.npm/_npx/c99440fc2d0a3f00/node_modules/@puppeteer/browsers/lib/install.js:118:12)
    at async #install (file:///home/build/.npm/_npx/c99440fc2d0a3f00/node_modules/@puppeteer/browsers/lib/CLI.js:392:9)
    at async Object.handler (file:///home/build/.npm/_npx/c99440fc2d0a3f00/node_modules/@puppeteer/browsers/lib/CLI.js:196:17)
```

This may be a bug in the package but if giving it unzip makes it happy then let's give it unzip.